### PR TITLE
Masthead: Better control over grid layout

### DIFF
--- a/x-govuk/components/masthead/README.md
+++ b/x-govuk/components/masthead/README.md
@@ -51,6 +51,7 @@ If you’re using Nunjucks macros in production with `html` options, or ones end
 | **image** | object | Options for image displayed on the right of the masthead on desktop layouts. See [image](#options-for-image). |
 | **phaseBanner** | object | Options for the phase banner component. See [phase banner component](https://design-system.service.gov.uk/components/phase-banner/) in the GOV.UK Design System. |
 | **breadcrumbs** | object | Options for the breadcrumbs component. See [breadcrumbs component](https://design-system.service.gov.uk/components/breadcrumbs/) in the GOV.UK Design System. |
+| **gridClass** | object | Classes from the start and end grid containers. See [gridClass](#options-for-gridClass) |
 | **caller** | nunjucks-block | Not strictly a parameter but [Nunjucks code convention](https://mozilla.github.io/nunjucks/templating.html#call). Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire masthead component in a `call` block. Content called this way appears between the breadcrumbs (if present) and the title. |
 
 ### Options for title
@@ -85,3 +86,10 @@ If you’re using Nunjucks macros in production with `html` options, or ones end
 | :--- | :--- | :---------- |
 | **src** | string | URL of image displayed on the right of the masthead on desktop layouts. |
 | **alt** | array | Alternative text for image. |
+
+### Options for gridClass
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| **start** | string | The [govuk grid class](https://design-system.service.gov.uk/styles/layout/#grid-system) applied to the container for the title, description and button elements. Defaults to `govuk-grid-column-two-thirds-from-desktop`. |
+| **end** | array | The [govuk grid class](https://design-system.service.gov.uk/styles/layout/#grid-system) applied to the container for the image elements. Defaults to `govuk-grid-column-one-third-from-desktop` if an image is supplied. |

--- a/x-govuk/components/masthead/template.njk
+++ b/x-govuk/components/masthead/template.njk
@@ -23,7 +23,7 @@
     }) if params.breadcrumbs }}
     {{- caller() if caller -}}
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
+      <div class="{{ params.gridClass.start or 'govuk-grid-column-two-thirds-from-desktop' }}">
       {% if params.title %}
         <h1 class="x-govuk-masthead__title{%- if params.title.classes %} {{ params.title.classes }}{% endif %}">
           {{ params.title.html | safe if params.title.html else params.title.text }}
@@ -47,7 +47,7 @@
       {% endif %}
       </div>
       {% if params.image %}
-      <div class="govuk-grid-column-one-third-from-desktop">
+      <div class="{{ params.gridClass.end or 'govuk-grid-column-one-third-from-desktop' }}">
         <div class="x-govuk-masthead__image">
           <img src="{{ params.image.src }}" alt="{{ params.image.alt }}"{% if not params.image.alt %} role="presentation"{% endif %}>
         </div>


### PR DESCRIPTION
I wanted a bigger image to match the rest of the layout of a product page I'm working on. This would give me better control.