### PR TITLE
Increase bottom padding of masthead component

### DIFF
--- a/x-govuk/components/masthead/_masthead.scss
+++ b/x-govuk/components/masthead/_masthead.scss
@@ -8,7 +8,7 @@ $x-govuk-masthead-colour: govuk-colour("white");
 @import "./tag";
 
 .x-govuk-masthead {
-  @include govuk-responsive-padding(6, "bottom");
+  @include govuk-responsive-padding(7, "bottom");
   padding-top: 0;
   color: $x-govuk-masthead-colour;
   background-color: $x-govuk-masthead-background-colour;


### PR DESCRIPTION
A spacing of `7` (40px) rather than `6` (30px) better matches the spacing at the top of the masthead, and the spacing between the bottom of the masthead and the top of any following text, such as a heading.

| Before | After |
|--|--|
| ![Screenshot 2022-05-23 at 17 34 00](https://user-images.githubusercontent.com/319055/169866440-2e2d9cd0-4e48-4c58-8bd6-77dfa995c90e.png) | ![Screenshot 2022-05-23 at 17 30 07](https://user-images.githubusercontent.com/319055/169866322-c3cd5dba-1170-48e7-97f0-d16565baedf6.png) |


