### PR TITLE
No grey border on related nav for first section

### DIFF
--- a/x-govuk/components/related-navigation/_related-navigation.scss
+++ b/x-govuk/components/related-navigation/_related-navigation.scss
@@ -31,6 +31,10 @@
 .x-govuk-related-navigation__nav-section {
   border-top: 1px solid govuk-colour("mid-grey");
   margin-bottom: govuk-spacing(6);
+
+  &:first-child {
+    border-top: none;
+  }
 }
 
 .x-govuk-related-navigation__link-list {


### PR DESCRIPTION
Otherwise there's a blue border and a grey border showing together

| Before | After |
|--|--|
| ![Screenshot 2022-06-01 at 15 14 34](https://user-images.githubusercontent.com/319055/171426219-faf48e80-13be-4425-8e42-4b19710fa6c4.png) | ![Screenshot 2022-06-01 at 15 15 09](https://user-images.githubusercontent.com/319055/171426209-81d95772-62ff-45ae-b6bb-9a3f1878eab2.png) |