### PR TITLE
Add component for handling unsaved changes

### DIFF
--- a/x-govuk/components/all.js
+++ b/x-govuk/components/all.js
@@ -1,5 +1,6 @@
 const Autocomplete = require('./autocomplete/autocomplete.js')
 const Edge = require('./edge/edge.js')
+const WarnOnUnsavedChanges = require('./warn-on-unsaved-changes/warn-on-unsaved-changes.js')
 
 /**
  * Get module name.
@@ -51,6 +52,7 @@ module.exports = (function () {
   // Add component modules to GOVUKPrototypeComponents object
   GOVUKPrototypeComponents.Autocomplete = Autocomplete
   GOVUKPrototypeComponents.Edge = Edge
+  GOVUKPrototypeComponents.WarnOnUnsavedChanges = WarnOnUnsavedChanges
 
   // Add GOVUKPrototypeComponents to window global
   window.GOVUKPrototypeComponents = GOVUKPrototypeComponents

--- a/x-govuk/components/warn-on-unsaved-changes/warn-on-unsaved-changes.js
+++ b/x-govuk/components/warn-on-unsaved-changes/warn-on-unsaved-changes.js
@@ -1,0 +1,25 @@
+module.exports = function () {
+  this.start = ($form) => {
+    let hasChanged = false
+
+    $form.addEventListener('submit', () => {
+      window.onbeforeunload = null
+    })
+
+    $form.addEventListener('change', () => {
+      hasChanged = true
+    })
+
+    window.onbeforeunload = (event) => {
+      if (!hasChanged) return
+
+      // Used to handle browsers that use legacy onbeforeunload
+      // https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+      event.preventDefault()
+
+      event.returnValue =
+        'You have unsaved changes, are you sure you want to leave?'
+      return event.returnValue
+    }
+  }
+}


### PR DESCRIPTION
Sometimes users navigate away from a form before saving their changes. This can lead to users losing what they entered.

This JS warns the user if they attempt to leave the page without saving, and is based on the JS written for Apply for teacher training:
https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/frontend/packs/warn-on-unsaved-changes.js

Usage in a prototype:
`<form data-module="warn-on-unsaved-changes" ...>`