### PR TITLE
Include `node_modules` in Sass imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,12 @@ Node.js v16 or later.
 To import all the Sass rules from GOV.UK Prototype Components, add the following to your Sass file:
 
 ```scss
-@import "govuk-prototype-components/x-govuk/all";
+@import "node_modules/govuk-prototype-components/x-govuk/all";
 ```
 
 #### Import an individual component’s CSS using a single import
 
-You can also import a component and all its dependencies without importing `node_modules/govuk-prototype-components/x-govuk/all` first.
-
-To import the masthead component for example, add the following to your Sass file:
+You can also import a styles for an individual component. For example, to import the masthead component, add the following to your Sass file:
 
 ```scss
 @import "node_modules/govuk-prototype-components/x-govuk/components/masthead/masthead";

--- a/x-govuk/components/autocomplete/_autocomplete.scss
+++ b/x-govuk/components/autocomplete/_autocomplete.scss
@@ -1,4 +1,4 @@
-@import "accessible-autocomplete/src/autocomplete";
+@import "node_modules/accessible-autocomplete/src/autocomplete";
 
 // Ensure the autocomplete uses the correct typeface
 .autocomplete__wrapper {


### PR DESCRIPTION
Partially supersedes #31.

Rather than ask authors to update their `loadPaths`, we should use explicit paths for our Sass imports, and use the same in our documentation.

This PR updates the import path for accessible autocomplete styles to include `node_modules`, and updates the documentation to always reference `node_modules` in the provided examples. This is inline with [the instructions used by GOV.UK Frontend](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/).  