### PR TITLE
Allow button component (not linked) to be decorated

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ You can then import the component macros as you would those provided by GOV.UK F
 
     ```diff
     {% raw %}
+    - {% from "govuk/components/button/macro.njk" import govukButton %}
+    + {% from "x-govuk/components/decorated/button/macro.njk" import govukButton with context %}
     - {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
     + {% from "x-govuk/components/decorated/checkboxes/macro.njk" import govukCheckboxes with context %}
     - {% from "govuk/components/date-input/macro.njk" import govukDateInput %}

--- a/tests/fixtures/button-href.njk
+++ b/tests/fixtures/button-href.njk
@@ -1,0 +1,7 @@
+{% from "x-govuk/components/decorated/button/macro.njk" import govukButton with context %}
+
+{{ govukButton({
+  decorate: "status",
+  href: "#",
+  text: "Publish"
+}) }}

--- a/tests/fixtures/button.njk
+++ b/tests/fixtures/button.njk
@@ -1,0 +1,6 @@
+{% from "x-govuk/components/decorated/button/macro.njk" import govukButton with context %}
+
+{{ govukButton({
+  decorate: "status",
+  text: "Publish"
+}) }}

--- a/tests/lib/decorate.mjs
+++ b/tests/lib/decorate.mjs
@@ -22,7 +22,8 @@ test.before(t => {
         day: '31',
         month: '12',
         year: '1999'
-      }
+      },
+      status: 'published'
     }
   }
 })
@@ -73,6 +74,22 @@ test('Decorates form component with items (data stored in array)', t => {
   t.regex(result, /for="country-2"/)
   t.regex(result, /id="country".*name="\[country\].*value="england".*checked/)
   t.regex(result, /id="country-2".*name="\[country\].*value="scotland"/)
+})
+
+test('Decorates button component', t => {
+  const { nunjucks, data } = t.context
+  const result = nunjucks.render('button.njk', data)
+
+  t.regex(result, /name="\[status\]"/)
+  t.regex(result, /value="published"/)
+})
+
+test('Does not decorate button link component', t => {
+  const { nunjucks, data } = t.context
+  const result = nunjucks.render('button-href.njk', data)
+
+  t.notRegex(result, /name="\[status\]"/)
+  t.notRegex(result, /value="published"/)
 })
 
 test('Uses label text if no value given for option', t => {

--- a/x-govuk/components/decorated/button/macro.njk
+++ b/x-govuk/components/decorated/button/macro.njk
@@ -1,0 +1,4 @@
+{% from "govuk/components/button/macro.njk" import govukButton as source %}
+{% macro govukButton(params) %}
+  {{ source(params) if params.href else source(decorate(params, params.decorate)) }}
+{% endmacro %}


### PR DESCRIPTION
While perhaps rarer than the need to decorate other form components, buttons (when not links) are also form components that may need to be decorated, if only with data names and values.

This PR adds a decorated button component, alongside tests to ensure links do not get decorated.

Fixes #4.