### PR TITLE
Remove internal generated whitespace from decorated component macros

### DIFF
--- a/x-govuk/components/decorated/button/macro.njk
+++ b/x-govuk/components/decorated/button/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/button/macro.njk" import govukButton as source %}
-{% macro govukButton(params) %}
-  {{ source(params) if params.href else source(decorate(params, params.decorate)) }}
-{% endmacro %}
+{% from "govuk/components/button/macro.njk" import govukButton as source -%}
+  {%- macro govukButton(params) -%}
+  {{- source(params) if params.href else source(decorate(params, params.decorate)) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/checkboxes/macro.njk
+++ b/x-govuk/components/decorated/checkboxes/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes as source %}
-{% macro govukCheckboxes(params) %}
-  {{ source(decorate(params, params.decorate)) }}
-{% endmacro %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes as source -%}
+  {%- macro govukCheckboxes(params) -%}
+  {{- source(decorate(params, params.decorate)) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/date-input/macro.njk
+++ b/x-govuk/components/decorated/date-input/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/date-input/macro.njk" import govukDateInput as source %}
-{% macro govukDateInput(params) %}
-  {{ source(decorate(params, params.decorate, 'govukDateInput')) }}
-{% endmacro %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput as source -%}
+  {%- macro govukDateInput(params) -%}
+  {{- source(decorate(params, params.decorate, "govukDateInput")) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/file-upload/macro.njk
+++ b/x-govuk/components/decorated/file-upload/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/file-upload/macro.njk" import govukFileUpload as source %}
-{% macro govukFileUpload(params) %}
-  {{ source(decorate(params, params.decorate)) }}
-{% endmacro %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload as source -%}
+  {%- macro govukFileUpload(params) -%}
+  {{- source(decorate(params, params.decorate)) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/input/macro.njk
+++ b/x-govuk/components/decorated/input/macro.njk
@@ -1,4 +1,4 @@
 {% from "govuk/components/input/macro.njk" import govukInput as source %}
-{% macro govukInput(params) %}
-  {{ source(decorate(params, params.decorate)) }}
-{% endmacro %}
+  {%- macro govukInput(params) -%}
+  {{- source(decorate(params, params.decorate)) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/radios/macro.njk
+++ b/x-govuk/components/decorated/radios/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/radios/macro.njk" import govukRadios as source %}
-{% macro govukRadios(params) %}
-  {{ source(decorate(params, params.decorate)) }}
-{% endmacro %}
+{% from "govuk/components/radios/macro.njk" import govukRadios as source -%}
+  {%- macro govukRadios(params) -%}
+  {{- source(decorate(params, params.decorate)) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/select/macro.njk
+++ b/x-govuk/components/decorated/select/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/select/macro.njk" import govukSelect as source %}
-{% macro govukSelect(params) %}
-  {{ source(decorate(params, params.decorate)) }}
-{% endmacro %}
+{% from "govuk/components/select/macro.njk" import govukSelect as source -%}
+  {%- macro govukSelect(params) -%}
+  {{- source(decorate(params, params.decorate)) -}}
+{%- endmacro %}

--- a/x-govuk/components/decorated/textarea/macro.njk
+++ b/x-govuk/components/decorated/textarea/macro.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/textarea/macro.njk" import govukTextarea as source %}
-{% macro govukTextarea(params) %}
-  {{ source(decorate(params, params.decorate)) }}
-{% endmacro %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea as source -%}
+  {%- macro govukTextarea(params) -%}
+  {{- source(decorate(params, params.decorate)) -}}
+{%- endmacro %}


### PR DESCRIPTION
Update decorated macros so that they don’t create any additional whitespace when included on pages. 💅 