### PR TITLE
Fix `aria-labelled-by` values

### DIFF
--- a/x-govuk/components/primary-navigation/template.njk
+++ b/x-govuk/components/primary-navigation/template.njk
@@ -1,7 +1,7 @@
-<nav class="x-govuk-primary-navigation {%- if params.classes %} {{ params.classes }}{% endif -%}" aria-labelledby="x-govuk-primary-navigation-heading"
+<nav class="x-govuk-primary-navigation {%- if params.classes %} {{ params.classes }}{% endif -%}" aria-labelledby="primary-navigation-heading"
 {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <div class="govuk-width-container">
-    <h2 class="govuk-visually-hidden" id="x-govuk-primary-navigation-heading">{{ params.visuallyHiddenTitle or "Menu" }}</h2>
+    <h2 class="govuk-visually-hidden" id="primary-navigation-heading">{{ params.visuallyHiddenTitle or "Menu" }}</h2>
     <ul class="x-govuk-primary-navigation__list">
       {%- for item in params.items %}
         {% if item.href %}

--- a/x-govuk/components/related-navigation/template.njk
+++ b/x-govuk/components/related-navigation/template.njk
@@ -3,8 +3,8 @@
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for section in params.sections %}
     {% set sectionTitle = section.title or "Related content" %}
-    <nav class="x-govuk-related-navigation__nav-section" role="navigation" aria-labelledby="related-nav-{{ sectionTitle | slugify }}">
-      <h{{ headingLevel }} class="x-govuk-related-navigation__main-heading" id="related-nav-related_items-{{ sectionTitle | slugify }}">
+    <nav class="x-govuk-related-navigation__nav-section" role="navigation" aria-labelledby="related-navigation-{{ sectionTitle | slugify }}">
+      <h{{ headingLevel }} class="x-govuk-related-navigation__main-heading" id="related-navigation-{{ sectionTitle | slugify }}">
         {{ sectionTitle }}
       </h{{ headingLevel }}>
       {% if section.items %}
@@ -17,9 +17,9 @@
         </ul>
       {% endif %}
       {% for subsection in section.subsections %}
-        <nav role="navigation" class="x-govuk-related-navigation__nav-section"{% if subsection.title %} aria-labelledby="related-nav-{{ subsection.title | slugify }}"{% endif %}>
+        <nav role="navigation" class="x-govuk-related-navigation__nav-section"{% if subsection.title %} aria-labelledby="related-navigation-{{ subsection.title | slugify }}"{% endif %}>
           {% if subsection.title %}
-            <h{{ headingLevel + 1 }} class="x-govuk-related-navigation__sub-heading" id="related-nav-topics-{{ subsection.title | slugify }}">
+            <h{{ headingLevel + 1 }} class="x-govuk-related-navigation__sub-heading" id="related-navigation-{{ subsection.title | slugify }}">
               {{ subsection.title }}
             </h{{ headingLevel + 1 }}>
           {% endif %}

--- a/x-govuk/components/sub-navigation/template.njk
+++ b/x-govuk/components/sub-navigation/template.njk
@@ -1,6 +1,6 @@
-<nav class="x-govuk-sub-navigation{%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="x-govuk-sub-navigation-heading"
+<nav class="x-govuk-sub-navigation{%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="sub-navigation-heading"
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{value}}"{% endfor %}>
-  <h2 class="govuk-visually-hidden" id="x-govuk-sub-navigation-heading">{{ params.visuallyHiddenTitle or "Pages in this section" }}</h2>
+  <h2 class="govuk-visually-hidden" id="sub-navigation-heading">{{ params.visuallyHiddenTitle or "Pages in this section" }}</h2>
   {% for theme, items in params.items | groupby("theme") %}
     {% if theme != "undefined" %}
       <h3 class="x-govuk-sub-navigation__theme">{{ theme }}</h3>


### PR DESCRIPTION
* Fix incorrect ARIA label values on related navigation component
* Remove `x-govuk-` from ARIA label values for other navigation components (official Design System components do not prefix their `id`s or ARIA labels