### PR TITLE
Remove dependency on decorate function for autocomplete component

### DIFF
--- a/x-govuk/components/autocomplete/template.njk
+++ b/x-govuk/components/autocomplete/template.njk
@@ -1,5 +1,4 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% set params = decorate(params, params.decorate) %}
 
 {# Only select the first item if a value hasn’t already been given #}
 {% set selectFirstItem = true %}
@@ -25,8 +24,13 @@
 
 {% set items = [] %}
 {% set addFirstItem = items.push(firstItem) %}
+
+{# Use text for item value if none provided #}
 {% for item in params.items %}
-  {% set addItem = items.push(item) %}
+  {% set addItem = items.push({
+    text: item.text,
+    value: item.value or item.text
+  }) %}
 {% endfor %}
 
 {{ govukSelect({


### PR DESCRIPTION
Currently, the autocomplete component requires the `decorate()` global Nunjucks function to be present for the component to work.

All this function does (and I’ll be damned if I can actually figure out or remember why) is ensure each option in the source `govukSelect` `items` param has a value for `value`, as this is what the accessible autocomplete JavaScript keys its behaviour from.

We can achieve the same using Nunjucks templating alone, removing the dependency. This is important because we want to make this package work (more) seamlessly with the Prototype Kit, and it’s extension system, as far as I can tell, doesn’t support adding filters or globals out of the box.