### PR TITLE
Use ES module syntax

### DIFF
--- a/x-govuk/components/all.js
+++ b/x-govuk/components/all.js
@@ -1,6 +1,6 @@
-const Autocomplete = require('./autocomplete/autocomplete.js')
-const Edge = require('./edge/edge.js')
-const WarnOnUnsavedChanges = require('./warn-on-unsaved-changes/warn-on-unsaved-changes.js')
+import Autocomplete from './autocomplete/autocomplete.js'
+import Edge from './edge/edge.js'
+import WarnOnUnsavedChanges from './warn-on-unsaved-changes/warn-on-unsaved-changes.js'
 
 /**
  * Get module name.
@@ -28,7 +28,7 @@ const _getModuleName = (string) => {
  * @example
  * [data-module="foo-bar"] initiates GOVUKPrototypeComponents.FooBar()
  */
-module.exports = (function () {
+export default (function () {
   const GOVUKPrototypeComponents = window.GOVUKPrototypeComponents || {}
 
   // Initiate all component modules

--- a/x-govuk/components/autocomplete/autocomplete.js
+++ b/x-govuk/components/autocomplete/autocomplete.js
@@ -1,6 +1,6 @@
-const accessibleAutocomplete = require('accessible-autocomplete')
+import accessibleAutocomplete from 'accessible-autocomplete'
 
-module.exports = function ($module) {
+export default function ($module) {
   this.init = () => {
     if (!$module) {
       return

--- a/x-govuk/components/edge/edge.js
+++ b/x-govuk/components/edge/edge.js
@@ -1,6 +1,6 @@
-const events = require('eventslibjs')
+import events from 'eventslibjs'
 
-module.exports = function ($module) {
+export default function ($module) {
   this.init = () => {
     if (!$module) {
       return

--- a/x-govuk/components/warn-on-unsaved-changes/warn-on-unsaved-changes.js
+++ b/x-govuk/components/warn-on-unsaved-changes/warn-on-unsaved-changes.js
@@ -1,4 +1,4 @@
-module.exports = function ($module) {
+export default function ($module) {
   this.init = () => {
     if (!$module) {
       return


### PR DESCRIPTION
…and we’ll export more widely compatible JS in a subsequent PR.