### PR TITLE
Improve compatibility with GOV.UK Prototype Kit v13

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,28 +37,13 @@ npm install govuk-prototype-components --save
 
 ## Usage with the GOV.UK Prototype Kit
 
-Add the component imports to `app/views/layout.html`, directly after the imports from GOV.UK Frontend:
+GOV.UK Prototype Components are designed to work with the GOV.UK Prototype Kit.
 
-```njk
-{% raw %}{% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete with context %}
-{% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}
-{% from "x-govuk/components/primary-navigation/macro.njk" import xGovukPrimaryNavigation %}
-{% from "x-govuk/components/related-navigation/macro.njk" import xGovukRelatedNavigation %}
-{% from "x-govuk/components/sub-navigation/macro.njk" import xGovukSubNavigation %}
-{% from "x-govuk/components/summary-card/macro.njk" import xGovukSummaryCard %}
-{% from "x-govuk/components/task-list/macro.njk" import xGovukTaskList %}{% endraw %}
-```
-
-To initialise those components which use JavaScript, add the following line to `app/assets/javascript/application.js`:
-
-```diff
-  window.GOVUKPrototypeKit.documentReady(() => {
-    // Add JavaScript here
-+   window.GOVUKPrototypeComponents.initAll()
-  })
-```
+If you are using v13 or later of the kit, the components will be immediately available once you have installed the package, and can be [managed alongside other plugins in your prototype](https://prototype-kit.service.gov.uk/docs/install-and-use-plugins).
 
 ## Advanced usage
+
+If you are using an earlier version of the GOV.UK Prototype Kit, or only want to install selected components, you can do so by following the instructions below.
 
 ### CSS
 

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,11 +1,42 @@
 {
   "nunjucksPaths": [
-    "/"
+    "/x-govuk/components/"
+  ],
+  "nunjucksMacros": [
+    {
+      "importFrom": "autocomplete/macro.njk",
+      "macroName": "xGovukAutocomplete"
+    },
+    {
+      "importFrom": "masthead/macro.njk",
+      "macroName": "xGovukMasthead"
+    },
+    {
+      "importFrom": "primary-navigation/macro.njk",
+      "macroName": "xGovukPrimaryNavigation"
+    },
+    {
+      "importFrom": "related-navigation/macro.njk",
+      "macroName": "xGovukRelatedNavigation"
+    },
+    {
+      "importFrom": "sub-navigation/macro.njk",
+      "macroName": "xGovukSubNavigation"
+    },
+    {
+      "importFrom": "summary-card/macro.njk",
+      "macroName": "xGovukSummaryCard"
+    },
+    {
+      "importFrom": "task-list/macro.njk",
+      "macroName": "xGovukTaskList"
+    }
   ],
   "sass": [
     "/x-govuk/all.scss"
   ],
   "scripts": [
-    "/x-govuk/all.js"
+    "/x-govuk/all.js",
+    "/govuk-prototype-kit/init.js"
   ]
 }

--- a/govuk-prototype-kit/init.js
+++ b/govuk-prototype-kit/init.js
@@ -1,0 +1,7 @@
+if (window.GOVUKPrototypeKit &&
+  window.GOVUKPrototypeKit.documentReady &&
+  window.GOVUKPrototypeKit.majorVersion >= 13) {
+  window.GOVUKPrototypeKit.documentReady(function () {
+    window.GOVUKPrototypeComponents.initAll()
+  })
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "license": "MIT",
   "files": [
-    "x-govuk",
-    "govuk-prototype-kit.config.json"
+    "govuk-prototype-kit.config.json",
+    "govuk-prototype-kit",
+    "x-govuk"
   ],
   "main": "x-govuk/all.js",
   "module": "x-govuk/all.mjs",


### PR DESCRIPTION
With the official introduction of plugins in GOV.UK Prototype Kit v13, it’s now possible to make installation even easier.

Users no longer need to manually add Nunjucks imports, and following the lead of GOV.UK Frontend, we can also provide an init JavaScript to load the JavaScript components.

This PR:

* Uses new `nunjucksMacros` config option to provide the locations of macros to import
* Adds an `init.js` to load the JavaScript used by the components
* Updates `README.md` to remove the previous installation instructions, and makes it clear that the advanced guidance is for earlier versions of the GOV.UK Prototype Kit.