### PR TITLE
Add example templates

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -38,5 +38,32 @@
   "scripts": [
     "/x-govuk/all.js",
     "/govuk-prototype-kit/init.js"
+  ],
+  "templates": [
+    {
+      "name": "Autocomplete question page",
+      "path": "/govuk-prototype-kit/templates/autocomplete.html",
+      "type": "nunjucks"
+    },
+    {
+      "name": "Masthead page",
+      "path": "/govuk-prototype-kit/templates/masthead.html",
+      "type": "nunjucks"
+    },
+    {
+      "name": "Primary navigation page",
+      "path": "/govuk-prototype-kit/templates/primary-navigation.html",
+      "type": "nunjucks"
+    },
+    {
+      "name": "Related navigation page",
+      "path": "/govuk-prototype-kit/templates/related-navigation.html",
+      "type": "nunjucks"
+    },
+    {
+      "name": "Sub navigation page",
+      "path": "/govuk-prototype-kit/templates/sub-navigation.html",
+      "type": "nunjucks"
+    }
   ]
 }

--- a/govuk-prototype-kit/templates/autocomplete.html
+++ b/govuk-prototype-kit/templates/autocomplete.html
@@ -1,0 +1,66 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Autocomplete question page template – {{ serviceName }} – GOV.UK Prototype Components
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <form class="form" action="/url/of/next/page" method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ xGovukAutocomplete({
+          id: "country",
+          name: "country",
+          allowEmpty: false,
+          label: {
+            classes: "govuk-label--l",
+            isPageHeading: true,
+            text: "Country of birth"
+          },
+          hint: {
+            test: "For example, Austria or Belgium"
+          },
+          items: [
+            { text: "Austria" },
+            { text: "Belgium" },
+            { text: "Bulgaria" },
+            { text: "Croatia" },
+            { text: "Republic of Cyprus" },
+            { text: "Czech Republic" },
+            { text: "Denmark" },
+            { text: "Estonia" },
+            { text: "Finland" },
+            { text: "France" },
+            { text: "Germany" },
+            { text: "Greece" },
+            { text: "Hungary" },
+            { text: "Ireland" },
+            { text: "Italy" },
+            { text: "Latvia" },
+            { text: "Lithuania" },
+            { text: "Luxembourg" },
+            { text: "Malta" },
+            { text: "Netherlands" },
+            { text: "Poland" },
+            { text: "Portugal" },
+            { text: "Romania" },
+            { text: "Slovakia" },
+            { text: "Slovenia" },
+            { text: "Spain" },
+            { text: "Sweden" }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/govuk-prototype-kit/templates/masthead.html
+++ b/govuk-prototype-kit/templates/masthead.html
@@ -1,0 +1,43 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Masthead page template – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block main %}
+  {{ xGovukMasthead({
+    classes: "x-govuk-masthead--large",
+    phaseBanner: {
+      text: "This is a new service"
+    },
+    title: {
+      text: "Page title"
+    },
+    description: {
+      text: "This is a paragraph of text. It gives some context for this page and wraps across several lines."
+    },
+    startButton: {
+      href: "#"
+    }
+  }) }}
+
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m">
+            Page content heading
+          </h2>
+
+          <p>Content goes here.</p>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/govuk-prototype-kit/templates/primary-navigation.html
+++ b/govuk-prototype-kit/templates/primary-navigation.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Primary navigation page template – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: serviceName,
+    serviceUrl: "/",
+    classes: "govuk-header__container--full-width",
+    containerClasses: "govuk-width-container"
+  }) }}
+{% endblock %}
+
+{% block main %}
+  {{ xGovukPrimaryNavigation({
+    visuallyHiddenTitle: "Site navigation",
+    items: [{
+      text: "Page 1",
+      href: "#"
+    }, {
+      text: "Page 2",
+      href: "#"
+    }]
+  }) }}
+
+  <div class="govuk-width-container">
+    {{ govukBackLink({
+      href: "javascript:window.history.back()"
+    }) }}
+
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">
+            Heading goes here
+          </h1>
+
+          <p>Content goes here.</p>
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/govuk-prototype-kit/templates/related-navigation.html
+++ b/govuk-prototype-kit/templates/related-navigation.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Related navigation page template – {{ serviceName }} – GOV.UK Prototype Components
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        Heading goes here
+      </h1>
+
+      <p>Content goes here.</p>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      {{ xGovukRelatedNavigation({
+        sections: [{
+          items: [{
+            text: "Related link",
+            href: "#"
+          }, {
+            text: "Related link",
+            href: "#"
+          }],
+          subsections: [{
+            title: "Subsection",
+            items: [{
+              text: "Related link",
+              href: "#"
+            }]
+          }]
+        }]
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/govuk-prototype-kit/templates/sub-navigation.html
+++ b/govuk-prototype-kit/templates/sub-navigation.html
@@ -1,0 +1,47 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Sub navigation page template – {{ serviceName }} – GOV.UK Prototype Components
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      {{ xGovukSubNavigation({
+        visuallyHiddenTitle: "Section navigation",
+        items: [{
+          text: "Page 1",
+          href: "#",
+          current: true
+        }, {
+          text: "Page 2",
+          href: "#"
+        }, {
+          text: "Page 3",
+          href: "#",
+          parent: true,
+          children: [{
+            text: "First child of page 3",
+            href: "#"
+          }, {
+            text: "Second child of page 3",
+            href: "#"
+          }]
+        }]
+      }) }}
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        Heading goes here
+      </h1>
+
+      <p>Content goes here.</p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Page templates for 5 of the included components. No templates included for Summary Card and Task List components, as these will be removed from the project in a subsequent release. 

## Autocomplete question page template

![autocomplete](https://user-images.githubusercontent.com/813383/214388961-8f932b75-c029-49e3-8e86-7d3899bbf157.png)

## Masthead page template

![masthead](https://user-images.githubusercontent.com/813383/214388974-0ddf83bf-e8eb-4c2c-a68f-dc9496a449a3.png)

## Primary navigation page template

![primary-navigation](https://user-images.githubusercontent.com/813383/214388980-2e84bcad-76b6-4736-a42f-8a300a06d9f0.png)

## Related navigation page template

![related-navigation](https://user-images.githubusercontent.com/813383/214388988-a4d13893-87ef-4581-bd37-e96a343499b1.png)

## Sub navigation page template

![sub-navigation](https://user-images.githubusercontent.com/813383/214388995-f798d7fa-1df8-450d-ac59-2ed5c095bcaa.png)
