### PR TITLE
Move package under x-govuk organisation namespace on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Node.js v16 or later.
 ## Installation
 
 ```shell
-npm install govuk-prototype-components --save
+npm install @x-govuk/govuk-prototype-components
 ```
 
 ## Usage with the GOV.UK Prototype Kit
@@ -46,13 +46,13 @@ If you are using an earlier version of the GOV.UK Prototype Kit, or only want to
 To import all the Sass rules from GOV.UK Prototype Components, add the following to your Sass file:
 
 ```scss
-@import "node_modules/govuk-prototype-components/x-govuk/all";
+@import "node_modules/@x-govuk/govuk-prototype-components/x-govuk/all";
 ```
 
 You can also import Sass rules for an individual component. For example, to import styles for the masthead component, add the following to your Sass file:
 
 ```scss
-@import "node_modules/govuk-prototype-components/x-govuk/components/masthead/masthead";
+@import "node_modules/@x-govuk/govuk-prototype-components/x-govuk/components/masthead/masthead";
 ```
 
 ### JavaScript
@@ -66,8 +66,8 @@ To import the JavaScript for the GOV.UK Prototype Components, you can either:
 
 If you decide to add the JavaScript to your HTML, first either:
 
-* set up your routing so that requests for the JavaScript file are served from `node_modules/govuk-prototype-components/x-govuk/all.js`
-* copy the `node_modules/govuk-prototype-components/x-govuk/all.js` file into your application
+* set up your routing so that requests for the JavaScript file are served from `node_modules/@x-govuk/govuk-prototype-components/x-govuk/all.js`
+* copy the `node_modules/@x-govuk/govuk-prototype-components/x-govuk/all.js` file into your application
 
 Then import the JavaScript file before the closing `</body>` tag of your HTML page or page template, and run the `initAll` function to initialise all the components.
 
@@ -86,7 +86,7 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 If you decide to import using a bundler, use `import` to import all GOV.UK Prototype Components, then run the `initAll` function to initialise them:
 
 ```js
-import { initAll } from 'govuk-prototype-components'
+import { initAll } from '@x-govuk/govuk-prototype-components'
 
 initAll()
 ```
@@ -94,7 +94,7 @@ initAll()
 You can also import the JavaScript for an individual component. For example, to import the autocomplete component, add the following to your JavaScript file:
 
 ```js
-import { Autocomplete } from 'govuk-prototype-components'
+import { Autocomplete } from '@x-govuk/govuk-prototype-components'
 
 const myAutocomplete = document.querySelector('#my-autocomplete')
 new Autocomplete(myAutocomplete).init()
@@ -105,7 +105,7 @@ new Autocomplete(myAutocomplete).init()
 If you’re using a bundler that uses CommonJS (like [Browserify](http://browserify.org/)), use `require`:
 
 ```js
-const GOVUKPrototypeComponents = require('govuk-prototype-components')
+const GOVUKPrototypeComponents = require('@x-govuk/govuk-prototype-components')
 
 GOVUKPrototypeComponents.initAll()
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "govuk-prototype-components",
+  "name": "@x-govuk/govuk-prototype-components",
   "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "govuk-prototype-components",
+      "name": "@x-govuk/govuk-prototype-components",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk-prototype-components",
+  "name": "@x-govuk/govuk-prototype-components",
   "version": "1.1.0",
   "description": "Common and experimental components that are not yet part of the GOV.UK Design System",
   "keywords": [


### PR DESCRIPTION
To make it clearer that this is not a GDS-owned or endorsed project, this PR readies the package for being moved under the `@x-govuk` organisation on NPM, and updates associated documentation.

When version 2.0.0 of this package is published, this new namespace will used.

Fixes #106.