### PR TITLE
Add plugin metadata.

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,4 +1,12 @@
 {
+  "meta": {
+    "description": "Common and experimental components that are not yet part of the GOV.UK Design System",
+    "urls": {
+      "documentation": "https://github.com/x-govuk/govuk-prototype-components#readme",
+      "releaseNotes": "https://github.com/x-govuk/govuk-prototype-components/releases/tag/v{{version}}",
+      "versionHistory": "https://github.com/x-govuk/govuk-prototype-components/releases"
+    }
+  },
   "nunjucksPaths": [
     "/x-govuk/components/"
   ],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "eleventy --quiet",
     "start": "eleventy --serve --quiet",
     "lint": "standard && stylelint 'x-govuk/**/*.scss'",
-    "test": "npm run lint"
+    "test": "npm run lint && npx govuk-prototype-kit@latest validate-plugin"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
We're working on a new plugin page, we'll be making use of new metadata that comes from plugin config.  This PR adds that metadata.

I've also added the validator to the tests, this uses `npx` and `@latest` to always look at the latest requirements.  I recommend this approach but it does erode the purity of repeatable builds, you could hardcode a version number in there or install `govuk-prototype-kit` as a (dev) dependency and remove both `npx` and `@latest`.