### PR TITLE
Specify compatibility with govuk-frontend v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "accessible-autocomplete": "^2.0.4",
-        "eventslibjs": "^1.2.0",
-        "govuk-prototype-kit": "^13.13.1"
+        "eventslibjs": "^1.2.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -30,7 +29,7 @@
         "govuk-prototype-kit": "^13.13.1"
       },
       "peerDependencies": {
-        "govuk-frontend": "^4.1.0"
+        "govuk-frontend": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "govuk-prototype-kit": "^13.13.1"
   },
   "peerDependencies": {
-    "govuk-frontend": "^4.1.0"
+    "govuk-frontend": "^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
The plugin works with either v4 or v5 of govuk-frontend