### PR TITLE
Increase height of primary navigation bar

### DIFF
--- a/x-govuk/components/primary-navigation/_primary-navigation.scss
+++ b/x-govuk/components/primary-navigation/_primary-navigation.scss
@@ -23,8 +23,8 @@
   box-sizing: border-box;
   display: block;
   float: left;
-  line-height: 50px;
-  height: 50px;
+  line-height: 55px;
+  height: 55px;
   padding: 0 govuk-spacing(3);
   position: relative;
 }


### PR DESCRIPTION
This bumps the height of the primary navigation bar up from 50px to 55px.

Whilst the version of this bar on the [Design System website](https://design-system.service.gov.uk) is 50px tall, the [version in the MOJ Design System](https://design-patterns.service.justice.gov.uk/components/primary-navigation/) is 55px tall, as is the one used by [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk) and some other DfE services.

The draft [One Login service header](https://github.com/alphagov/di-govuk-one-login-service-header) is taller again, at 60px, however that also includes the service name as an h2.

For now, 60px feels like a better balance?

## Screenshots

### Before

<img width="1083" alt="Screenshot 2023-10-31 at 13 13 48" src="https://github.com/x-govuk/govuk-prototype-components/assets/30665/f20a5c76-7827-4f74-8b45-c4c39b80b342">

### After

<img width="1098" alt="Screenshot 2023-10-31 at 13 13 59" src="https://github.com/x-govuk/govuk-prototype-components/assets/30665/1f188769-3adc-44b0-b2fe-1c19b047b101">
