### PR TITLE
Support previews for full width components

### DIFF
--- a/docs/_components/example/_example.scss
+++ b/docs/_components/example/_example.scss
@@ -3,7 +3,9 @@
   border: 0;
   border-right: 1px solid $govuk-border-colour;
   display: block;
-  max-width: 100%;
+  padding: govuk-spacing(4);
+  max-width: calc(100% - govuk-spacing(4) * 2);
+  resize: both;
   width: 100%;
 }
 
@@ -14,8 +16,12 @@
 .app-example__tabs {
   // stylelint-disable selector-max-id
   .govuk-tabs__panel#preview {
+    background: govuk-colour("light-grey");
     padding: 0;
-    padding-right: 1px;
+  }
+
+  .x-govuk-code {
+    margin: 0;
   }
 }
 

--- a/docs/_layouts/example-full-width.njk
+++ b/docs/_layouts/example-full-width.njk
@@ -1,8 +1,6 @@
 {% extends "layouts/base.njk" %}
 {% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete %}
 
-{% set mainClasses = "govuk-!-padding-bottom-1" %}
-
 {% block head %}
   {{ super() }}
   <style>
@@ -12,7 +10,7 @@
 
 {% block header %}{% endblock %}
 
-{% block content %}
+{% block main %}
   {{ content }}
 {% endblock %}
 

--- a/docs/examples/masthead.njk
+++ b/docs/examples/masthead.njk
@@ -1,6 +1,6 @@
 ---
 eleventyExcludeFromCollections: true
-layout: example.njk
+layout: example-full-width.njk
 title: Masthead example
 ---
 {% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}

--- a/docs/examples/primary-navigation.njk
+++ b/docs/examples/primary-navigation.njk
@@ -1,6 +1,6 @@
 ---
 eleventyExcludeFromCollections: true
-layout: example.njk
+layout: example-full-width.njk
 title: Primary navigation
 ---
 {% from "x-govuk/components/primary-navigation/macro.njk" import xGovukPrimaryNavigation %}


### PR DESCRIPTION
I’d like to provide previews with examples of the masthead and primary navigation below a header in the documentation once the negative margins on those components have been removed (see #192). 

That’s quite hard to do currently as components examples use a template where the component appears within the content area of the base template.

This PR:

- Adds an `example-full-width` layout that can be used by the Masthead and Primary navigation examples
- Tweaks the styling of the example component (mostly spacing so that it looks good for both types of example)
- Remove the grey background on the base template to improve the previews when viewed in an `<iframe>`
- Adds the ability to resize the preview `<iframe>` so that you can see how components changes based on their context:

  <img width="755" alt="Screenshot of resizable iframe." src="https://github.com/x-govuk/govuk-prototype-components/assets/813383/7f998c64-696a-41de-b921-392aefe5de6b">


 