### PR TITLE
Use brand colour for current item border on primary navigation

### DIFF
--- a/x-govuk/components/primary-navigation/_primary-navigation.scss
+++ b/x-govuk/components/primary-navigation/_primary-navigation.scss
@@ -29,15 +29,7 @@
 }
 
 .x-govuk-primary-navigation__item--current {
-  border-bottom: $govuk-border-width-narrow solid $govuk-link-colour;
-
-  &:hover {
-    border-bottom-color: $govuk-link-hover-colour;
-  }
-
-  &:active {
-    border-bottom-color: $govuk-link-active-colour;
-  }
+  border-bottom: $govuk-border-width-narrow solid $govuk-brand-colour;
 }
 
 .x-govuk-primary-navigation__item--align-right {


### PR DESCRIPTION
* Use `$govuk-brand-colour` for current item highlight (in most cases however, the link and brand colour are the same).
* Remove adjusting the colour of this highlight on active/hover states, aligning the design with equivalent components used in related design systems (GDS, MoD, MoJ…).

<img width="260" alt="Screenshot of primary navigation with current item highlighted." src="https://github.com/x-govuk/govuk-prototype-components/assets/813383/f6bd2ac0-79dd-40ae-834f-01c796410a46">
