### PR TITLE
Update `govuk-eleventy-plugin` dependency (pre-release)

### DIFF
--- a/docs/_components/example/template.njk
+++ b/docs/_components/example/template.njk
@@ -24,9 +24,9 @@
     </li>
   </ul>
   <div class="govuk-tabs__panel" id="{{ params.example }}-preview">
-    <iframe class="app-example__frame" data-module="app-example-frame" src="{{ examplePath | url }}"></iframe>
+    <iframe class="app-example__frame" data-module="app-example-frame" src="{{ examplePath }}"></iframe>
     <p class="app-example__toolbar">
-      <a class="app-example__new-window" href="{{ examplePath | url }}" target="_blank">Open this example in a new tab</a>
+      <a class="app-example__new-window" href="{{ examplePath }}" target="_blank">Open this example in a new tab</a>
     </p>
   </div>
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="{{ params.example }}-html">

--- a/docs/_layouts/example-full-width.njk
+++ b/docs/_layouts/example-full-width.njk
@@ -15,8 +15,8 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ '/assets/iframeResizer.contentWindow.js' | url }}"></script>
-  <script src="{{ '/assets/x-govuk/all.js' | url }}"></script>
+  <script src="/assets/iframeResizer.contentWindow.js"></script>
+  <script src="/assets/x-govuk/all.js"></script>
   <script>
     window.GOVUKPrototypeComponents.initAll()
   </script>

--- a/docs/_layouts/example.njk
+++ b/docs/_layouts/example.njk
@@ -17,8 +17,8 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ '/assets/iframeResizer.contentWindow.js' | url }}"></script>
-  <script src="{{ '/assets/x-govuk/all.js' | url }}"></script>
+  <script src="/assets/iframeResizer.contentWindow.js"></script>
+  <script src="/assets/x-govuk/all.js"></script>
   <script>
     window.GOVUKPrototypeComponents.initAll()
   </script>

--- a/docs/_layouts/sub-navigation.njk
+++ b/docs/_layouts/sub-navigation.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/sub-navigation.njk" %}
 
 {% block scripts %}
-  <script src="{{ '/assets/iframeResizer.js' | url }}"></script>
+  <script src="/assets/iframeResizer.js"></script>
   <script>
     iFrameResize({}, `[data-module="app-example-frame"]`)
   </script>

--- a/docs/assets/sass/settings.scss
+++ b/docs/assets/sass/settings.scss
@@ -1,0 +1,2 @@
+$govuk-brand-colour: #2288aa;
+$govuk-font-family: system-ui, sans-serif;

--- a/docs/data-attributes.md
+++ b/docs/data-attributes.md
@@ -7,6 +7,6 @@ description: Use data attributes to help guide users during user research.
 
 {% for page in collections["data-attributes"] %}
 
-- [{{ page.data.title }}]({{ page.url | url }}) – {{ page.data.description }}
+- [{{ page.data.title }}]({{ page.url }}) – {{ page.data.description }}
 
 {% endfor %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ startButton:
 {% for item in collections.homepage %}
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link--no-visited-state" href="{{ item.url | url }}">{{ item.data.title | smart }}</a>
+      <a class="govuk-link--no-visited-state" href="{{ item.url }}">{{ item.data.title | smart }}</a>
     </h2>
     <p class="govuk-body">{{ item.data.description | markdown("inline") }}</p>
   </section>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -15,8 +15,6 @@ const getComponentContent = (componentName) => {
 module.exports = function (eleventyConfig) {
   // Plugins
   eleventyConfig.addPlugin(govukEleventyPlugin, {
-    brandColour: '#28a',
-    fontFamily: 'system-ui, sans-serif',
     icons: {
       mask: 'https://raw.githubusercontent.com/x-govuk/logo/main/images/x-govuk-mask-icon.svg?raw=true',
       shortcut:
@@ -31,13 +29,12 @@ module.exports = function (eleventyConfig) {
       url: 'https://x-govuk.github.io/#projects',
       name: 'X-GOVUK projects'
     },
-    url: process.env.GITHUB_ACTIONS
-      ? 'https://x-govuk.github.io/govuk-prototype-components/'
-      : '/',
+    url:
+      process.env.GITHUB_ACTIONS &&
+      'https://x-govuk.github.io/govuk-prototype-components/',
     stylesheets: ['/styles/application.css'],
     header: {
-      organisationLogo: 'x-govuk',
-      organisationName: 'X-GOVUK',
+      logotype: 'x-govuk',
       productName: 'Prototype Components',
       search: {
         indexPath: '/search.json',
@@ -135,6 +132,6 @@ module.exports = function (eleventyConfig) {
       layouts: '_layouts',
       includes: '_components'
     },
-    pathPrefix: process.env.GITHUB_ACTIONS ? '/govuk-prototype-components' : '/'
+    pathPrefix: process.env.GITHUB_ACTIONS && '/govuk-prototype-components'
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@11ty/eleventy": "^2.0.1",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "@x-govuk/govuk-eleventy-plugin": "^5.0.3",
+        "@x-govuk/govuk-eleventy-plugin": "x-govuk/govuk-eleventy-plugin",
         "@x-govuk/govuk-prototype-components": "file:./",
         "eslint": "^8.55.0",
         "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@11ty/eleventy": "^2.0.1",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@x-govuk/govuk-eleventy-plugin": "^5.0.3",
+    "@x-govuk/govuk-eleventy-plugin": "x-govuk/govuk-eleventy-plugin",
     "@x-govuk/govuk-prototype-components": "file:./",
     "eslint": "^8.55.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
Update to v6 pre-release version of `govuk-eleventy-plugin`, partly to fix layouts that in-turn depend on this project, partly to test the plugin on a separate site, and partly in the hope that it will stop the builds from failing.