### PR TITLE
Update example previews to use GOV.UK brand

### DIFF
--- a/docs/_layouts/example-full-width.njk
+++ b/docs/_layouts/example-full-width.njk
@@ -1,12 +1,11 @@
-{% extends "layouts/base.njk" %}
+{% extends "govuk/template.njk" %}
 {% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete %}
 
 {% block head %}
-  {{ super() }}
-  <style>
-    .govuk-template { background-color: transparent; }
-  </style>
+  <link rel="stylesheet" href="/assets/example.css">
 {% endblock %}
+
+{% block skipLink %}{% endblock %}
 
 {% block header %}{% endblock %}
 
@@ -14,7 +13,7 @@
   {{ content }}
 {% endblock %}
 
-{% block scripts %}
+{% block bodyEnd %}
   <script src="/assets/iframeResizer.contentWindow.js"></script>
   <script src="/assets/x-govuk/all.js"></script>
   <script>

--- a/docs/_layouts/example.njk
+++ b/docs/_layouts/example.njk
@@ -1,14 +1,11 @@
-{% extends "layouts/base.njk" %}
+{% extends "govuk/template.njk" %}
 {% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete %}
 
-{% set mainClasses = "govuk-!-padding-bottom-1" %}
-
 {% block head %}
-  {{ super() }}
-  <style>
-    .govuk-template { background-color: transparent; }
-  </style>
+  <link rel="stylesheet" href="/assets/example.css">
 {% endblock %}
+
+{% block skipLink %}{% endblock %}
 
 {% block header %}{% endblock %}
 
@@ -16,7 +13,7 @@
   {{ content }}
 {% endblock %}
 
-{% block scripts %}
+{% block bodyEnd %}
   <script src="/assets/iframeResizer.contentWindow.js"></script>
   <script src="/assets/x-govuk/all.js"></script>
   <script>

--- a/docs/assets/example.scss
+++ b/docs/assets/example.scss
@@ -1,0 +1,7 @@
+$govuk-canvas-background-colour: transparent;
+
+// GOV.UK Frontend
+@import "govuk-frontend/dist/govuk/all";
+
+// GOV.UK Prototype components
+@import "@x-govuk/govuk-prototype-components/x-govuk/all";

--- a/docs/examples/masthead-below-primary-navigation.njk
+++ b/docs/examples/masthead-below-primary-navigation.njk
@@ -5,7 +5,7 @@ title: Masthead example below primary navigation
 ---
 <style>
   .app-header--full-width-border {
-    border-bottom: 10px solid #2188aa;
+    border-bottom: 10px solid #1f70b8;
   }
 </style>
 

--- a/docs/examples/primary-navigation-below-header.njk
+++ b/docs/examples/primary-navigation-below-header.njk
@@ -5,7 +5,7 @@ title: Primary navigation example below header
 ---
 <style>
   .app-header--full-width-border {
-    border-bottom: 10px solid #2188aa;
+    border-bottom: 10px solid #1f70b8;
   }
 </style>
 

--- a/docs/examples/primary-navigation-below-phase-banner.njk
+++ b/docs/examples/primary-navigation-below-phase-banner.njk
@@ -5,7 +5,7 @@ title: Primary navigation example below phase banner
 ---
 <style>
   .app-header--full-width-border {
-    border-bottom: 10px solid #2188aa;
+    border-bottom: 10px solid #1f70b8;
   }
 
   .app-phase-banner--no-border {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1318,7 +1318,7 @@
     },
     "node_modules/@x-govuk/govuk-eleventy-plugin": {
       "version": "5.0.7",
-      "resolved": "git+ssh://git@github.com/x-govuk/govuk-eleventy-plugin.git#1829d18dbf70cfde8a33bd72abe59fd312e87de7",
+      "resolved": "git+ssh://git@github.com/x-govuk/govuk-eleventy-plugin.git#7fe9b440115412b211239cc0851c81ee3c20c53a",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Publish a separate stylesheet (`example.css`) that uses default GOV.UK Frontend settings.
- Inherit from the GOV.UK Frontend base template for the example layouts
- Remove skip link from examples (Fixing #199) 