### PR TITLE
Add supported versions to documentation

### DIFF
--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 2
+order: 3
 title: Autocomplete
 description: Help users find and select from a number of options.
 ---

--- a/docs/data-attributes.md
+++ b/docs/data-attributes.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 7
+order: 8
 title: Data attributes
 description: Use data attributes to help guide users during user research.
 ---

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -6,7 +6,10 @@ title: Get started
 
 ## Requirements
 
-Node.js v18 or later.
+- Node.js v18 or later.
+- GOV.UK Frontend v5 or later.
+
+See [supported versions](/supported-versions) for more details.
 
 ## Installation
 

--- a/docs/masthead.md
+++ b/docs/masthead.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 3
+order: 4
 title: Masthead
 description: Introduce users to your product or service.
 ---

--- a/docs/primary-navigation.md
+++ b/docs/primary-navigation.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 4
+order: 5
 title: Primary navigation
 description: Link to the primary sections of your service.
 ---

--- a/docs/related-navigation.md
+++ b/docs/related-navigation.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 5
+order: 6
 title: Related navigation
 description: Show related content when prototyping guidance pages.
 ---

--- a/docs/secondary-navigation.md
+++ b/docs/secondary-navigation.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 5
+order: 6
 title: Secondary navigation
 description: Allow users to navigate between pages scoped to a section.
 ---

--- a/docs/sub-navigation.md
+++ b/docs/sub-navigation.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 6
+order: 7
 title: Sub navigation
 description: Link to sibling pages in a multi-page section of your service.
 ---

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -1,0 +1,13 @@
+---
+layout: sub-navigation
+order: 2
+title: Supported versions
+---
+
+GOV.UK Prototype Components are actively maintained and support the latest stable versions of the [GOV.UK Frontend](https://frontend.design-system.service.gov.uk), [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk) and [Node JS](https://nodejs.org).
+
+| GOV.UK Prototype Components | {{ pkg.version }} | 2.2.2   |
+| --------------------------- | ----------------- | ------- |
+| GOV.UK Frontend             | 5.0.0             | 4.7.0   |
+| GOV.UK Prototype Kit        | 13.16.0           | 13.16.0 |
+| Node JS                     | 18.0.0            | 18.0.0  |


### PR DESCRIPTION
Taking a leaf out of @peteryates’ book, show the versions of the GOV.UK Frontend, GOV.UK Prototype Kit and Node JS that this package supports:

<img width="750" alt="Screenshot of supported versions table." src="https://github.com/x-govuk/govuk-prototype-components/assets/813383/29ec59a3-a725-445a-8f47-750538817d39">

This page is linked to from the Getting started page:

<img width="390" alt="Screenshot of requirements shown in Getting started page." src="https://github.com/x-govuk/govuk-prototype-components/assets/813383/6956bcaf-73b4-4f48-a5ed-e4eda70af470">

This should help clarify what’s supported, and help diagnose any issues arising from using versions of the package with unsupported dependencies (see #209).