### PR TITLE
Correct sub navigation component in Prototype Kit template

### DIFF
--- a/govuk-prototype-kit/templates/sub-navigation.html
+++ b/govuk-prototype-kit/templates/sub-navigation.html
@@ -17,8 +17,7 @@
         visuallyHiddenTitle: "Section navigation",
         items: [{
           text: "Page 1",
-          href: "#",
-          current: true
+          href: "#"
         }, {
           text: "Page 2",
           href: "#"
@@ -28,7 +27,8 @@
           parent: true,
           children: [{
             text: "First child of page 3",
-            href: "#"
+            href: "#",
+            current: true
           }, {
             text: "Second child of page 3",
             href: "#"


### PR DESCRIPTION
The sub navigation template provided to the Prototype Kit currently shows an incorrect state, with a parent without children being shown as current, but then children for a parent being show which is not current. To demonstrate both children and current items, this PR moves the currently active item to one of the child pages. 

| Before | After |
| - | - |
| <img width="240" alt="Screenshot of sub navigation showing incorrect item highlighting." src="https://github.com/x-govuk/govuk-prototype-components/assets/813383/bf207989-a3f5-47f0-a604-0b5f5a9d9d3b"> | <img width="260" alt="Screenshot of sub navigation showing correct item highlighting." src="https://github.com/x-govuk/govuk-prototype-components/assets/813383/00e74e15-a2e6-4ac0-b971-0da080b61985"> |