### PR TITLE
Conditional navigation items

### DIFF
--- a/x-govuk/components/primary-navigation/template.njk
+++ b/x-govuk/components/primary-navigation/template.njk
@@ -4,7 +4,7 @@
     <h2 class="govuk-visually-hidden" id="primary-navigation-heading">{{ params.visuallyHiddenTitle or "Menu" }}</h2>
     <ul class="x-govuk-primary-navigation__list">
       {%- for item in params.items %}
-        {% if item.href %}
+        {% if item %}
           <li class="x-govuk-primary-navigation__item {{ "x-govuk-primary-navigation__item--current" if item.current }}{% if item.classes %} {{ item.classes }}{% endif -%}">
             <a class="x-govuk-primary-navigation__link" {{ "aria-current=page" if item.current }} href="{{ item.href }}">
               {{- item.text -}}

--- a/x-govuk/components/primary-navigation/template.njk
+++ b/x-govuk/components/primary-navigation/template.njk
@@ -3,15 +3,15 @@
   <div class="govuk-width-container">
     <h2 class="govuk-visually-hidden" id="primary-navigation-heading">{{ params.visuallyHiddenTitle or "Menu" }}</h2>
     <ul class="x-govuk-primary-navigation__list">
-      {%- for item in params.items %}
-        {% if item %}
-          <li class="x-govuk-primary-navigation__item {{ "x-govuk-primary-navigation__item--current" if item.current }}{% if item.classes %} {{ item.classes }}{% endif -%}">
-            <a class="x-govuk-primary-navigation__link" {{ "aria-current=page" if item.current }} href="{{ item.href }}">
-              {{- item.text -}}
-            </a>
-          </li>
-        {% endif %}
-      {% endfor -%}
+    {%- for item in params.items %}
+      {% if item %}
+      <li class="x-govuk-primary-navigation__item {{ "x-govuk-primary-navigation__item--current" if item.current }}{% if item.classes %} {{ item.classes }}{% endif -%}">
+        <a class="x-govuk-primary-navigation__link" {{ "aria-current=page" if item.current }} href="{{ item.href }}">
+          {{- item.text -}}
+        </a>
+      </li>
+      {% endif %}
+    {% endfor -%}
     </ul>
   </div>
 </nav>

--- a/x-govuk/components/related-navigation/template.njk
+++ b/x-govuk/components/related-navigation/template.njk
@@ -1,39 +1,39 @@
 {% set headingLevel = params.headingLevel or 2 %}
 <div class="x-govuk-related-navigation{%- if params.classes %} {{ params.classes }}{% endif -%}"
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  {% for section in params.sections %}
-    {% set sectionTitle = section.title or "Related content" %}
-    {% set sectionId = section.id or sectionTitle | lower | replace(" ", "-") %}
-    <nav class="x-govuk-related-navigation__nav-section" role="navigation" aria-labelledby="related-navigation-{{ sectionId }}">
-      <h{{ headingLevel }} class="x-govuk-related-navigation__main-heading" id="related-navigation-{{ sectionId }}">
-        {{ sectionTitle }}
-      </h{{ headingLevel }}>
-      {% if section.items %}
+{% for section in params.sections %}
+  {% set sectionTitle = section.title or "Related content" %}
+  {% set sectionId = section.id or sectionTitle | lower | replace(" ", "-") %}
+  <nav class="x-govuk-related-navigation__nav-section" role="navigation" aria-labelledby="related-navigation-{{ sectionId }}">
+    <h{{ headingLevel }} class="x-govuk-related-navigation__main-heading" id="related-navigation-{{ sectionId }}">
+      {{ sectionTitle }}
+    </h{{ headingLevel }}>
+    {% if section.items %}
+    <ul class="x-govuk-related-navigation__link-list">
+    {% for item in section.items %}
+      <li class="x-govuk-related-navigation__link">
+        <a class="govuk-link x-govuk-related-navigation__section-link x-govuk-related-navigation__section-link--other" href="{{ item.href }}">{{ item.text }}</a>
+      </li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+    {% for subsection in section.subsections %}
+      {% set subsectionId = subsection.id or subsection.title | lower | replace(" ", "-") %}
+      <nav role="navigation" class="x-govuk-related-navigation__nav-section"{% if subsection.title %} aria-labelledby="related-navigation-{{ subsectionId }}"{% endif %}>
+        {% if subsection.title %}
+        <h{{ headingLevel + 1 }} class="x-govuk-related-navigation__sub-heading" id="related-navigation-{{ subsectionId }}">
+          {{ subsection.title }}
+        </h{{ headingLevel + 1 }}>
+        {% endif %}
         <ul class="x-govuk-related-navigation__link-list">
-          {% for item in section.items %}
-            <li class="x-govuk-related-navigation__link">
-              <a class="govuk-link x-govuk-related-navigation__section-link x-govuk-related-navigation__section-link--other" href="{{ item.href }}">{{ item.text }}</a>
-            </li>
-          {% endfor %}
+        {% for item in subsection.items %}
+          <li class="x-govuk-related-navigation__link">
+            <a class="govuk-link x-govuk-related-navigation__section-link" href="{{ item.href }}">{{ item.text }}</a>
+          </li>
+        {% endfor %}
         </ul>
-      {% endif %}
-      {% for subsection in section.subsections %}
-        {% set subsectionId = subsection.id or subsection.title | lower | replace(" ", "-") %}
-        <nav role="navigation" class="x-govuk-related-navigation__nav-section"{% if subsection.title %} aria-labelledby="related-navigation-{{ subsectionId }}"{% endif %}>
-          {% if subsection.title %}
-            <h{{ headingLevel + 1 }} class="x-govuk-related-navigation__sub-heading" id="related-navigation-{{ subsectionId }}">
-              {{ subsection.title }}
-            </h{{ headingLevel + 1 }}>
-          {% endif %}
-          <ul class="x-govuk-related-navigation__link-list">
-            {% for item in subsection.items %}
-              <li class="x-govuk-related-navigation__link">
-                <a class="govuk-link x-govuk-related-navigation__section-link" href="{{ item.href }}">{{ item.text }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-        </nav>
-      {% endfor %}
-    </nav>
-  {% endfor %}
+      </nav>
+    {% endfor %}
+  </nav>
+{% endfor %}
 </div>

--- a/x-govuk/components/secondary-navigation/template.njk
+++ b/x-govuk/components/secondary-navigation/template.njk
@@ -1,13 +1,13 @@
 <nav class="x-govuk-secondary-navigation {%- if params.classes %} {{ params.classes }}{% endif -%}" {% if params.labelledBy %}aria-labelledby="{{ params.labelledBy }}"{% else %}aria-label="{{ params.visuallyHiddenTitle or "Secondary menu" }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <ul class="x-govuk-secondary-navigation__list">
-    {% for item in params.items %}
-      {% if item %}
-      <li class="x-govuk-secondary-navigation__list-item {{ "x-govuk-secondary-navigation__list-item--current" if item.current }}{% if item.classes %} {{ item.classes }}{% endif -%}">
-        <a class="x-govuk-secondary-navigation__link" href="{{ item.href }}" {{ "aria-current=page" if item.current }}>
-          {{ item.text }}
-        </a>
-      </li>
-      {% endif %}
-    {% endfor %}
+  {% for item in params.items %}
+    {% if item %}
+    <li class="x-govuk-secondary-navigation__list-item {{ "x-govuk-secondary-navigation__list-item--current" if item.current }}{% if item.classes %} {{ item.classes }}{% endif -%}">
+      <a class="x-govuk-secondary-navigation__link" href="{{ item.href }}" {{ "aria-current=page" if item.current }}>
+        {{ item.text }}
+      </a>
+    </li>
+    {% endif %}
+  {% endfor %}
   </ul>
 </nav>

--- a/x-govuk/components/secondary-navigation/template.njk
+++ b/x-govuk/components/secondary-navigation/template.njk
@@ -1,11 +1,13 @@
 <nav class="x-govuk-secondary-navigation {%- if params.classes %} {{ params.classes }}{% endif -%}" {% if params.labelledBy %}aria-labelledby="{{ params.labelledBy }}"{% else %}aria-label="{{ params.visuallyHiddenTitle or "Secondary menu" }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <ul class="x-govuk-secondary-navigation__list">
     {% for item in params.items %}
+      {% if item %}
       <li class="x-govuk-secondary-navigation__list-item {{ "x-govuk-secondary-navigation__list-item--current" if item.current }}{% if item.classes %} {{ item.classes }}{% endif -%}">
         <a class="x-govuk-secondary-navigation__link" href="{{ item.href }}" {{ "aria-current=page" if item.current }}>
           {{ item.text }}
         </a>
       </li>
+      {% endif %}
     {% endfor %}
   </ul>
 </nav>

--- a/x-govuk/components/sub-navigation/template.njk
+++ b/x-govuk/components/sub-navigation/template.njk
@@ -1,27 +1,27 @@
 <nav class="x-govuk-sub-navigation{%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="sub-navigation-heading"
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{value}}"{% endfor %}>
   <h2 class="govuk-visually-hidden" id="sub-navigation-heading">{{ params.visuallyHiddenTitle or "Pages in this section" }}</h2>
-  {% for theme, items in params.items | groupby("theme") %}
-    {% if theme != "undefined" %}
-      <h3 class="x-govuk-sub-navigation__theme">{{ theme }}</h3>
-    {% endif %}
-    <ul class="x-govuk-sub-navigation__section">
-      {% for item in items %}
-        {% if item %}
-        <li class="x-govuk-sub-navigation__section-item{% if item.parent or item.current %} x-govuk-sub-navigation__section-item--current{% endif %}">
-          <a class="x-govuk-sub-navigation__link" href="{{ item.href }}"{% if item.current %} aria-current="true"{% endif %}>{{ item.text }}</a>
-          {% if item.parent and item.children | length > 0 %}
-            <ul class="x-govuk-sub-navigation__section x-govuk-sub-navigation__section--nested">
-              {% for child in item.children %}
-                <li class="x-govuk-sub-navigation__section-item">
-                  <a class="x-govuk-sub-navigation__link" href="{{ child.href }}"{% if child.current %} aria-current="true"{% endif %}>{{ child.text }}</a>
-                </li>
-              {% endfor %}
-            </ul>
-          {% endif %}
+{% for theme, items in params.items | groupby("theme") %}
+  {% if theme != "undefined" %}
+  <h3 class="x-govuk-sub-navigation__theme">{{ theme }}</h3>
+  {% endif %}
+  <ul class="x-govuk-sub-navigation__section">
+  {% for item in items %}
+    {% if item %}
+    <li class="x-govuk-sub-navigation__section-item{% if item.parent or item.current %} x-govuk-sub-navigation__section-item--current{% endif %}">
+      <a class="x-govuk-sub-navigation__link" href="{{ item.href }}"{% if item.current %} aria-current="true"{% endif %}>{{ item.text }}</a>
+      {% if item.parent and item.children | length > 0 %}
+      <ul class="x-govuk-sub-navigation__section x-govuk-sub-navigation__section--nested">
+      {% for child in item.children %}
+        <li class="x-govuk-sub-navigation__section-item">
+          <a class="x-govuk-sub-navigation__link" href="{{ child.href }}"{% if child.current %} aria-current="true"{% endif %}>{{ child.text }}</a>
         </li>
-        {% endif %}
       {% endfor %}
-    </ul>
+      </ul>
+      {% endif %}
+    </li>
+    {% endif %}
   {% endfor %}
+  </ul>
+{% endfor %}
 </nav>

--- a/x-govuk/components/sub-navigation/template.njk
+++ b/x-govuk/components/sub-navigation/template.njk
@@ -7,6 +7,7 @@
     {% endif %}
     <ul class="x-govuk-sub-navigation__section">
       {% for item in items %}
+        {% if item %}
         <li class="x-govuk-sub-navigation__section-item{% if item.parent or item.current %} x-govuk-sub-navigation__section-item--current{% endif %}">
           <a class="x-govuk-sub-navigation__link" href="{{ item.href }}"{% if item.current %} aria-current="true"{% endif %}>{{ item.text }}</a>
           {% if item.parent and item.children | length > 0 %}
@@ -19,6 +20,7 @@
             </ul>
           {% endif %}
         </li>
+        {% endif %}
       {% endfor %}
     </ul>
   {% endfor %}


### PR DESCRIPTION
Makes it possible to add conditions to navigation items:

```
{{ xGovukSecondaryNavigation({
  classes: "nhsuk-u-margin-bottom-6",
  items: [
    {
      text: "Apples",
      href: "/apples/"
    } if role == "juicer",
    {
      text: "Bananas",
      href: "/bananas/"
    },
    {
      text: "Oranges",
      href: "/oranges/"
    } if role == "juicer"
  ]
}) }}
```

Without this change, an empty object is returned, which in turn creates an empty HTML list item.

The Primary navigation component previously checked for the presence of `item.href`, but have made this consistent so that only `item` need be present.

Also updated the indentation to be a bit more consistent across the navigation components, see edbb9f6f44288973b5c0c55ba8bb438d9cb9e040 for the actual changes.