### PR TITLE
Add notification banner to primary nav component

### DIFF
--- a/docs/primary-navigation.md
+++ b/docs/primary-navigation.md
@@ -6,6 +6,11 @@ description: Link to the primary sections of your service.
 ---
 
 {% from "example/macro.njk" import appExample %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{{ govukNotificationBanner({
+  html: "### This component will be removed in future\n\nUse the [service navigation component](https://design-system.service.gov.uk/components/service-navigation/) in the GOV.UK Design System instead." | markdown
+}) }}
 
 {{ appExample({
   example: "primary-navigation"


### PR DESCRIPTION
This aims to alert users that the Primary navigation component will be removed in future, and users should use the Service navigation component from the GOV.UK Design System instead.

We could add this straight away, do a minor release which mentions the deprecation in the release notes, and then remove the component completely in the next major release, in #246?

### Screenshot

<img width="1174" alt="Screenshot of page with the heading Primary navigation showing a banner at the top saying This component will be removed in future. Use the service navigation component in the GOV.UK Design System instead." src="https://github.com/user-attachments/assets/4641b876-6aec-41d4-8fb7-793bb130dffa">
