### PR TITLE
Add release notes page

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,65 @@
+---
+layout: sub-navigation
+order: 1
+title: Release notes
+---
+
+This page documents the changes in major and minor releases, including upgrade notes. See [release notes on GitHub](https://github.com/x-govuk/govuk-prototype-components/releases) for full details of patch releases.
+
+[[toc]]
+
+## Version 3.0
+
+December 2023
+
+### Breaking changes
+
+- Removes the negative top margin of the [Masthead component](/masthead/). Instead, follow instructions on the Masthead component page to remove the blue border from the bottom of the GOV.UK header using a custom class.
+- Removes the `x-govuk-masthead--large` variant of the Masthead - this class can now be removed.
+- Removes the negative top margin from the [Primary navigation component](/primary-navigation/). Instead, follow the instructions on the Primary navigation component to remove the bottom border from either the phase banner or to make the blue order at the bottom of the GOV.UK Header full width.
+- Updates to use version 5.0 of GOV.UK Frontend
+
+### New features
+
+- Adds the [secondary navigation component](/secondary-navigation/)
+
+## Version 2.2
+
+December 2023
+
+- Updates minimum Node.js requirement to version 18 or above
+- Updates minimum GOV.UK Prototype Kit version to 13.15
+- Other dependency updates
+
+## Version 2.1
+
+November 2023
+
+- Removes horizontal padding within [primary navigation](/primary-navigation)
+- Increases height of the [primary navigation](/primary-navigation)
+- Adds support for Node.js version 20
+
+## Version 2.0
+
+March 2023
+
+### Breaking changes
+
+- Removes the task list component as this has been added to the GOV.UK Design system
+- Removes the summary card component as this has been added to the GOV.UK Design system
+
+## Version 1.1
+
+January 2023
+
+- Add example templates
+- Improve compatibility with GOV.UK Prototype Kit version 13
+- Updates dependencies
+
+## Version 1.0
+
+August 2022
+
+First version of GOV.UK Prototype Components.
+
+After 5 months of testing and iteration, this first release provides canonical code for a number of components that are widely used across government, but do not yet form part of the GOV.UK Design System.


### PR DESCRIPTION
This is a quick idea to add a 'release notes' page where we can document the features and deprecations of major and minor releases in a more accessible way.

This does duplicate the [GitHub releases page](https://github.com/x-govuk/govuk-prototype-components/releases), but that's possibly harder to follow with all the patch releases and links to specific commits?

The GOV.UK Design System team put all of this detail in their [release notes on GitHub](https://github.com/alphagov/govuk-frontend/releases) (including some great upgrade instructions), but the NHS Design System has quite a nice [Updates page](https://service-manual.nhs.uk/whats-new/updates) which is quite nice.

This is partly motivated by wanting somewhere to link people to if they need help to switch from the Primary navigation component to the new Service navigation component... 🤔 

Thoughts? (Content and layout is very rough).

### Screenshot

![release-notes](https://github.com/user-attachments/assets/850cf439-fe6f-4050-a6cb-21e8bc08af0f)
