### PR TITLE
Primary navigation dependency notices

### DIFF
--- a/docs/primary-navigation.md
+++ b/docs/primary-navigation.md
@@ -9,7 +9,7 @@ description: Link to the primary sections of your service.
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {{ govukNotificationBanner({
-  html: "### This component will be removed in future\n\nUse the [service navigation component](https://design-system.service.gov.uk/components/service-navigation/) in the GOV.UK Design System instead." | markdown
+  html: "### This component will be removed in a future release\n\nUse the [service navigation component](https://design-system.service.gov.uk/components/service-navigation/) in the GOV.UK Design System instead." | markdown
 }) }}
 
 {{ appExample({

--- a/x-govuk/components/primary-navigation/_primary-navigation.scss
+++ b/x-govuk/components/primary-navigation/_primary-navigation.scss
@@ -1,3 +1,5 @@
+@warn "Primary navigation component styles are deprecated, and will be removed in v4.0. Use the service navigation component from the GOV.UK Design System instead.";
+
 .x-govuk-primary-navigation {
   @include govuk-font(19, $weight: bold);
   background-color: govuk-colour("light-grey");


### PR DESCRIPTION
Uses `@warn` to generate a deprecation notice when using the primary navigation styles.

Was thinking could also log a warning when using the Nunjucks component, but that would require a filter, and the components are provided as standalone macros. I don’t think it’s possible to log messages to the console from within Nunjucks template code, so will have to rely on the notice from Sass alone.