### PR TITLE
Responsive styles for secondary navigation component

### DIFF
--- a/x-govuk/components/secondary-navigation/_secondary-navigation.scss
+++ b/x-govuk/components/secondary-navigation/_secondary-navigation.scss
@@ -1,69 +1,64 @@
+$xgovuk-secondary-navigation-current-link-border-width: govuk-spacing(1);
+
 .x-govuk-secondary-navigation {
-  @include govuk-font(19);
+  border-bottom: 1px solid $govuk-border-colour;
 }
 
 .x-govuk-secondary-navigation__link {
   @include govuk-link-common;
-  @include govuk-link-style-no-visited-state;
   @include govuk-link-style-no-underline;
-
-  // Extend the touch area of the link to the list
-  &::after {
-    bottom: 0;
-    content: "";
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
+  @include govuk-link-style-no-visited-state;
 }
 
 .x-govuk-secondary-navigation__list {
-  @include govuk-clearfix;
-
-  // The list uses box-shadow rather than a border to set a 1px
-  // grey line at the bottom, so that border from the current
-  // item appears on top of the grey line.
-  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+  @include govuk-font(19);
   list-style: none;
   margin: 0;
+  margin-bottom: govuk-spacing(3);
   padding: 0;
-  width: 100%;
+
+  @include govuk-media-query($from: tablet) {
+    align-items: start;
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: 0;
+  }
+
+  // IE11 trips over flexbox and doesn’t wrap anything, making all of the items
+  // into a single, horizontally scrolling row. This CSS hack removes the
+  // flexbox definition for IE 10 & 11, reverting it a non-flexbox version.
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    display: block;
+  }
 }
 
 .x-govuk-secondary-navigation__list-item {
-  box-sizing: border-box;
-  display: block;
-  float: left;
-  margin-right: govuk-spacing(4);
-  padding-bottom: govuk-spacing(2);
-  padding-top: govuk-spacing(2);
+  border: 0 solid $govuk-link-colour;
+  margin: govuk-spacing(2) 0;
   position: relative;
 
-  // More generous padding beneath items on wider screens
   @include govuk-media-query($from: tablet) {
-    padding-bottom: govuk-spacing(3);
-  }
-}
+    margin-bottom: 0;
+    margin-top: 0;
+    padding: govuk-spacing(4) 0;
 
-// The last item of the list doesn’t need any spacing to its right.
-// Removing this prevents the item from wrapping to the next line
-// unnecessarily.
-.x-govuk-secondary-navigation__list-item:last-child {
-  margin-right: 0;
+    &:not(:last-child) {
+      @include govuk-responsive-margin(6, $direction: right);
+    }
+  }
 }
 
 .x-govuk-secondary-navigation__list-item--current {
-  border-bottom: $govuk-border-width solid $govuk-brand-colour;
-  padding-bottom: govuk-spacing(1);
-
-  // More generous padding beneath items on wider screens
-  @include govuk-media-query($from: tablet) {
-    padding-bottom: govuk-spacing(2);
+  @include govuk-media-query($until: tablet) {
+    border-left-width: $xgovuk-secondary-navigation-current-link-border-width;
+    // Negative offset the left margin so we can place a current page indicator
+    // to the left without misaligning the list item text.
+    margin-left: ((govuk-spacing(2) + $xgovuk-secondary-navigation-current-link-border-width) * -1);
+    padding-left: govuk-spacing(2);
   }
-}
 
-.x-govuk-secondary-navigation__list-item--current .x-govuk-secondary-navigation__link:link,
-.x-govuk-secondary-navigation__list-item--current .x-govuk-secondary-navigation__link:visited {
-  color: $govuk-text-colour;
+  @include govuk-media-query($from: tablet) {
+    border-bottom-width: $xgovuk-secondary-navigation-current-link-border-width;
+    padding-bottom: govuk-spacing(4) - $xgovuk-secondary-navigation-current-link-border-width;
+  }
 }


### PR DESCRIPTION
Fixes #270, and builds on #273.

@benfraserdesign correctly reported that the responsive styles for the secondary navigation component could be improved. His PR in #273 goes someway to addressing the responsiveness, but by using table display, the navigation breaks if there are too many items and/or their labels are long.

This PR builds on this work, using the design of equally spaced navigation items with centred text labels between mobile and tablet breakpoints. Below the mobile breakpoint, and above the tablet breakpoint, the navigation more closely follows the design of the [service navigation component](https://design-system.service.gov.uk/components/service-navigation/), which wasn’t a thing when this component (or the components that inspired it) was first designed. SCSS from the service navigation component is liberally applied here.

## < Mobile

| | Screenshot |
| - | - |
| Before | ![Screenshot of mobile layout before.](https://github.com/user-attachments/assets/73066ccb-c938-4414-ad4c-9853d9ca4a1d) |
| After | ![Screenshot of mobile layout after.](https://github.com/user-attachments/assets/5f8d2052-78be-400a-b58f-d6db50378613) |

## Mobile > Tablet

| | Screenshot |
| - | - |
| Before | ![Screenshot of tablet layout before.](https://github.com/user-attachments/assets/90cd0533-352b-43bf-85c5-3ff736fe9db4) |
| After | ![Screenshot of tablet layout after.](https://github.com/user-attachments/assets/7228bae3-225a-4990-9599-092114f2d8c9) |

## > Tablet

| | Screenshot |
| - | - |
| Before | ![Screenshot of desktop layout before.](https://github.com/user-attachments/assets/35c44abf-df97-44fd-9fe9-86a9bd6017ce) |
| After | ![Screenshot of desktop layout after.](https://github.com/user-attachments/assets/7dcd5b97-82ed-4260-9a3f-303b93f6af81) |