### PR TITLE
Fix link in service navigation on docs site

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -146,5 +146,6 @@ export default function (eleventyConfig) {
       layouts: '_layouts',
       includes: '_components'
     },
+    pathPrefix: process.env.GITHUB_ACTIONS && '/govuk-prototype-components/'
   }
 }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -146,6 +146,5 @@ export default function (eleventyConfig) {
       layouts: '_layouts',
       includes: '_components'
     },
-    pathPrefix: process.env.GITHUB_ACTIONS && '/govuk-prototype-components'
   }
 }


### PR DESCRIPTION
The link to the homepage in the service navigation on [the docs site](https://x-govuk.github.io/govuk-prototype-components/) is currently broken as it goes to `/govuk-prototype-components/govuk-prototype-components/`.

Not _entirely_ sure why - some combination of the `pathPrefix` and the `serviceUrl` doesn't seem to work.

This fixes it by adding a trailing slash to the `pathPrefix`, which is what the govuk-eleventy-plugin docs site does: https://github.com/x-govuk/govuk-eleventy-plugin/blob/main/eleventy.config.js#L97