### PR TITLE
Export sass for individual components

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,21 @@
       "import": "./src/x-govuk/index.js",
       "module-sync": "./src/x-govuk/index.js",
       "sass": "./src/x-govuk/index.scss"
+    },
+    "autocomplete": {
+      "sass": "./src/x-govuk/autocomplete/index.scss"
+    },
+    "masthead": {
+      "sass": "./src/x-govuk/masthead/index.scss"
+    },
+    "related-navigation": {
+      "sass": "./src/x-govuk/related-navigation/index.scss"
+    },
+    "secondary-navigation": {
+      "sass": "./src/x-govuk/secondary-navigation/index.scss"
+    },
+    "sub-navigation": {
+      "sass": "./src/x-govuk/sub-navigation/index.scss"
     }
   }
 }


### PR DESCRIPTION
Currently, [the documentation](https://x-govuk.github.io/govuk-prototype-components/get-started/) says you can do this to import individual components using the sass module system:

```
@forward "pkg:@x-govuk/govuk-prototype-components/masthead";
```

However that throws an error:

```
Error: Can't find stylesheet to import.
  ╷
1 │ @forward "pkg:@x-govuk/govuk-prototype-components/masthead";
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

To fix it, I think we need to specify the individual components within the `exports` key in the `package.json` - see [Sass Node.js package importer](https://sass-lang.com/documentation/at-rules/use/#node-js-package-importer)

Hard to test this without doing a release though?!

cc @colinrotherham @paulrobertlloyd