### PR TITLE
Add a build of the CSS to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 npm-debug.log
 _site
 .DS_Store
+tmp/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lint:scss:fix": "stylelint '**/*.scss' --fix",
     "lint": "npm run lint:prettier && npm run lint:js && npm run lint:scss",
     "lint:fix": "npm run lint:prettier:fix && npm run lint:js:fix && npm run lint:scss:fix",
-    "test": "npm run lint && npx govuk-prototype-kit@latest validate-plugin",
+    "test": "npm run lint && npx govuk-prototype-kit@latest validate-plugin && npm run test:css",
+    "test:css": "npx sass --pkg-importer=node --load-path=. --quiet-deps src/x-govuk/index.scss ./tmp/output.css",
     "prepublishOnly": "npm run package",
     "package": "rollup --config",
     "release": "np"


### PR DESCRIPTION
The tests currently just run a code linter and validate the prototype plugin config but don’t actually compile the sass at all.

This adds a compile of the sass to the tests.

There might be a better way to do this, but using the sass command line tool seemed simplest?

cc @colinrotherham @paulrobertlloyd